### PR TITLE
Fixes form javascript, sets to 500ft for development

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,11 +18,11 @@
 <div id='map'></div>
 <div class='pin-top fill-gray pad1'>
     Areas within 
-    <select name='distance'>
-        <option value='500'>500 feet</option>
+    <select name='distance' id='radius'>
+        <option value='500' selected='selected'>500 feet</option>
         <option value='1000'>1000 feet</option>
         <option value='2500'>2500 feet</option>
-        <option value='5280' selected='selected'>1 mile</option>
+        <option value='5280'>1 mile</option>
     </select>
     of a bike lane or protected bike infrastructure.
 </div>


### PR DESCRIPTION
Adds `id='radius'` so the JavaScript works again.