### PR TITLE
Upgrades mapbox.js, removes turf and unused leaflet plugins

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,15 +6,12 @@
 
 <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
 <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no' />
-<script src='https://api.tiles.mapbox.com/mapbox.js/v2.1.6/mapbox.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox.js/v2.1.6/mapbox.css' rel='stylesheet' />
-<script src='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-label/v0.2.1/leaflet.label.css' rel='stylesheet' />
+<script src='https://api.tiles.mapbox.com/mapbox.js/v2.4.0/mapbox.js'></script>
+<link href='https://api.tiles.mapbox.com/mapbox.js/v2.4.0/mapbox.css' rel='stylesheet' />
 <link href='styles.css' rel='stylesheet' />
 </head>
 
 <body>
-<script src='https://wzrd.in/standalone/turf@latest'></script>
 <div id='map'></div>
 <div class='pin-top fill-gray pad1'>
     Areas within 


### PR DESCRIPTION
* Upgrade mapbox.js from v2.1.6 to latest v2.4.0
* Removes turf (not used currently)
* Removes unused leaflet plugins

We should re-add turf when we move from pregenerated buffers to dynamic buffers, but for now we should remove it.