### PR TITLE
Adds workaround for local testing

### DIFF
--- a/site.js
+++ b/site.js
@@ -1,8 +1,16 @@
 (function() {
 
-    var lanesUrl = '/bikelanes/';
-    var buffersUrl = '/buffers/';
-    var countyUrl = '/counties/';
+    // if testing locally get data from local folders, else retrieve from GitHub Pages
+    if (location.hostname == 'localhost' || location.hostname == '127.0.0.1') {
+        var lanesUrl = '/bikelanes/';
+        var buffersUrl = '/buffers/';
+        var countyUrl = '/counties/';
+    } else {
+        var baseUrl = 'https://dcfemtech.github.io/hackforgood-waba-map/';
+        var lanesUrl = baseUrl + '/bikelanes/';
+        var buffersUrl = baseUrl + '/buffers/';
+        var countyUrl = baseUrl + '/counties/';
+    }
 
     // ======= regions =======
     var regions = {


### PR DESCRIPTION
Whoops, `var lanesUrl = '/buffers/';` becomes `https://dcfemtech.github.io/buffers/` on GitHub Pages and causes 404s.

This code should allow testing with local folders when using a development server, but get the correct URLs when viewing the production site on GitHub Pages.

The benefit of using local files when testing is that this can be used to preview changes to GeoJSON files locally before pushing to GitHub. It also offers a performance benefit when testing locally.