### PR TITLE
Use dcfemtech.com for baseUrl

### DIFF
--- a/site.js
+++ b/site.js
@@ -6,7 +6,7 @@
         var buffersUrl = '/buffers/';
         var countyUrl = '/counties/';
     } else {
-        var baseUrl = 'https://dcfemtech.github.io/hackforgood-waba-map/';
+        var baseUrl = 'https://dcfemtech.com/hackforgood-waba-map';
         var lanesUrl = baseUrl + '/bikelanes/';
         var buffersUrl = baseUrl + '/buffers/';
         var countyUrl = baseUrl + '/counties/';

--- a/site.js
+++ b/site.js
@@ -6,10 +6,10 @@
         var buffersUrl = '/buffers/';
         var countyUrl = '/counties/';
     } else {
-        var baseUrl = 'https://dcfemtech.com/hackforgood-waba-map';
-        var lanesUrl = baseUrl + '/bikelanes/';
-        var buffersUrl = baseUrl + '/buffers/';
-        var countyUrl = baseUrl + '/counties/';
+        var baseUrl = 'https://dcfemtech.com/hackforgood-waba-map/';
+        var lanesUrl = baseUrl + 'bikelanes/';
+        var buffersUrl = baseUrl + 'buffers/';
+        var countyUrl = baseUrl + 'counties/';
     }
 
     // ======= regions =======


### PR DESCRIPTION
https://dcfemtech.github.io/ now redirects to https://dcfemtech.com/ per https://github.com/dcfemtech/dcfemtech.github.io/issues/46.

This broke the bike lane GeoJSON layers for this web page, which WABA emailed me about today. This PR fixes the issue by updating the `baseUrl` variable to the new DCFemTech URL.

<img width="1412" alt="Screenshot 2019-07-10 22 07 31" src="https://user-images.githubusercontent.com/10409657/61017129-1241c980-a360-11e9-9aca-d1943a75c691.png">
