### PR TITLE
Refactor buffer generation script

### DIFF
--- a/scripts/generate-buffers.js
+++ b/scripts/generate-buffers.js
@@ -1,77 +1,70 @@
 #!/usr/bin/env node
 
-var turf = require('turf');
-var fs = require('fs');
-var path = require('path');
-var d3 = require('d3-queue');
+const turf = require('turf');
+const fs = require('fs');
+const path = require('path');
+const d3 = require('d3-queue');
 
-var q = d3.queue();
-
-var sourcePath = 'bikelanes';
-var clipPath = 'counties';
+const q = d3.queue();
 
 // See https://github.com/dcfemtech/hackforgood-waba-map/issues/1 for background
 
-function generateBuffers(name, geojson, clipFile, callback) {
-    try {
-        console.log('merging features for ' + name);
-        var unionedJson = featureUnion(geojson);
+function generateBuffers(bikeLaneFileName, bikeLaneJson, countyClipJson, callback) {
+  try {
+    console.log('Merging features for area ' + bikeLaneFileName);
+    const unionedJson = featureUnion(bikeLaneJson);
 
-        generateBuffer(unionedJson, 0.094697, clipFile, name + '_buffer_500ft.geojson');
-        generateBuffer(unionedJson, 0.189394, clipFile, name + '_buffer_1000ft.geojson');
-        generateBuffer(unionedJson, 0.4734848, clipFile, name + '_buffer_2500ft.geojson');
-        generateBuffer(unionedJson, 1, clipFile, name + '_buffer_1mile.geojson');
-
-    } catch (ex) {
-        console.log('ERROR! ' + ex);
-        callback(ex, name);
-    }
-    callback(null, name);
+    generateBuffer(unionedJson, 0.094697, countyClipJson, bikeLaneFileName + '_buffer_500ft.geojson');
+    generateBuffer(unionedJson, 0.189394, countyClipJson, bikeLaneFileName + '_buffer_1000ft.geojson');
+    generateBuffer(unionedJson, 0.4734848, countyClipJson, bikeLaneFileName + '_buffer_2500ft.geojson');
+    generateBuffer(unionedJson, 1, countyClipJson, bikeLaneFileName + '_buffer_1mile.geojson');
+  } catch(error) {
+    console.log(error);
+    callback(error, bikeLaneFileName);
+  }
+  callback(null, bikeLaneFileName);
 }
 
 function featureUnion(geojson){
-    var merged = geojson.features[0];
-    var length = geojson.features.length;
+  var merged = geojson.features[0];
+  var length = geojson.features.length;
 
-    for (var i = 1; i < length; i++) {
-        merged = turf.union(merged, geojson.features[i]);
-    }
-    
-    geojson.features = [merged];
+  for (var i = 1; i < length; i++) {
+    merged = turf.union(merged, geojson.features[i]);
+  }
+  geojson.features = [merged];
 
-    return geojson;
+  return geojson;
+}
+
+function generateBuffer(unionedJson, distanceInMiles, countyClipJson, bufferFileName) {
+  console.log('Generating buffer for ' + bufferFileName);
+  var buffer = turf.buffer(unionedJson, distanceInMiles, 'miles');
+  //clip buffer down to the jurisdictional boundaries
+  console.log('Clipping buffer for ' + bufferFileName);
+  buffer = turf.intersect(buffer, countyClipJson.features[0]);
+  const areaInSqMeters = turf.area(buffer);
+  const areaInSqKm = areaInSqMeters / 1000000;
+  const areaInSqMiles = areaInSqKm / 2.58999;
+  buffer.area = areaInSqMiles;
+  
+  fs.writeFileSync(path.resolve('buffers', bufferFileName), JSON.stringify(buffer));
 }
 
 function done(error, name) {
-    if (error) {
-        console.log('error [' + name + ']: ' + error);
-    } else {
-        console.log('done with ' + name);
-    }    
+  if (error) {
+    console.log('Error [' + name + ']: ' + error);
+  } else {
+    console.log('Done creating buffer for ' + name);
+  }    
 }
 
-function generateBuffer(geojson, distanceInMiles, clipFile, fileName) {
-    console.log('generating ' + fileName);
-    var buffer = turf.buffer(geojson, distanceInMiles, 'miles');
-    //clip buffer down to the jurisdictional boundaries
-    console.log('clipping buffer');
-    buffer = turf.intersect(buffer, clipFile.features[0]);
-    var areaInSqMeters = turf.area(buffer);
-    var areaInSqKm = areaInSqMeters / 1000000;
-    var areaInSqMiles = areaInSqKm / 2.58999;
-    buffer.area = areaInSqMiles;
-    
-    fs.writeFileSync(path.resolve('buffers', fileName), JSON.stringify(buffer));
-}
-
-var sourceFiles = fs.readdirSync(sourcePath);
-for (var i = 0; i < sourceFiles.length; i++) {
-    var sourceFileName = sourceFiles[i];
-    var sourceJson = JSON.parse(fs.readFileSync(path.resolve(sourcePath, sourceFileName)));
-    var sourceFileNameBase = sourceFileName.replace(/\.[^/.]+$/, '');
-    var clipFileName = sourceFileNameBase + '_Clip.geojson';
-    var clipFile = JSON.parse(fs.readFileSync(path.resolve(clipPath, clipFileName)));
-    q.defer(generateBuffers, sourceFileNameBase, sourceJson, clipFile);    
-}
+const bikeLaneFiles = fs.readdirSync('bikelanes');
+bikeLaneFiles.forEach(bikeLaneFile => {
+  const bikeLaneJson = JSON.parse(fs.readFileSync(path.resolve('bikelanes', bikeLaneFile)));
+  const bikeLaneFileName = bikeLaneFile.replace(/\.[^/.]+$/, '');
+  const countyClipFileName = bikeLaneFileName + '_Clip.geojson';
+  const countyClipJson = JSON.parse(fs.readFileSync(path.resolve('counties', countyClipFileName)));
+  q.defer(generateBuffers, bikeLaneFileName, bikeLaneJson, countyClipJson); 
+});
 q.await(done);
-


### PR DESCRIPTION
This PR refactors the buffer generation script (`npm run buffers`). It does the following:

* Switches from 4 spaces to 2 spaces for easier reading
* Switches from `var` to `const` where possible (ES6 syntax)
* Renames variables to make file name vs. geojson and bike lane vs. county polygon more clear

I am refactoring this to help with a follow up PR to upgrade `turf` to `@turf/turf`, which has several breaking changes. Not a straight forward upgrade.

I ran `npm run buffers` locally and this script worked before and after this refactor.